### PR TITLE
Nav bar goes all the way across in Firefox. Items don't stack in Firefox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ stacktrace.log
 /target-eclipse/
 *.iml
 .idea
+*.ipr

--- a/grails-app/views/index.gsp
+++ b/grails-app/views/index.gsp
@@ -53,27 +53,29 @@
 
         <!-- Three columns of text below the carousel -->
         <div class="row">
-            <div class="col-lg-4">
+            <div class="col-md-4">
                 <h2>Start a Chapter!</h2>
                 <asset:image src="Gr8LadiesYourTown.png" alt="Gr8Ladies logo your town here"
                              style="width: 70px; height: 70px;"/>
 
                 <p>We are always looking to expand to new areas.  To start a chapter in your city, email chapters@gr8ladies.org</p>
-            </div><!-- /.col-lg-4 -->
-            <div class="col-lg-4">
+            </div><!-- /.col-md-4 -->
+            <div class="col-md-4">
                 <h2>Workshops</h2>
                 <i class="fa fa-group fa-5x"></i>
 
                 <p>If you'd like to have Gr8Ladies host a workshop with your organization, please email us.</p>
-            </div><!-- /.col-lg-4 -->
-            <h2>Upcoming Events</h2>
-            <i class="fa fa-calendar fa-5x"></i>
+            </div><!-- /.col-md-4 -->
+            <div class="col-md=4">
+                <h2>Upcoming Events</h2>
+                <i class="fa fa-calendar fa-5x"></i>
 
-            <p>For a list of our upcoming events, please follow us on twitter
-            @<a href="http://twitter.com/gr8ladies" target="_blank">Gr8Ladies</a>
-            and check our <a href="http://meetup.com/gr8ladies" target="_blank">meetup</a> page.</p>
-        </div><!-- /.col-lg-4 -->
-    </div><!-- /.row -->
+                <p>For a list of our upcoming events, please follow us on twitter
+                @<a href="http://twitter.com/gr8ladies" target="_blank">Gr8Ladies</a>
+                and check our <a href="http://meetup.com/gr8ladies" target="_blank">meetup</a> page.</p>
+            </div><!-- /.col-md-4 -->
+        </div><!-- /.row -->
+    </div><!-- /.container -->
 
 
 <!-- START THE FEATURETTES -->

--- a/grails-app/views/layouts/header.gsp
+++ b/grails-app/views/layouts/header.gsp
@@ -18,7 +18,7 @@
 
 <body>
     <div class="container">
-        <div class="navbar-header">
+        <div class="nav-wrap">
         <ul id="social-media-links" class="nav nav-pills nav-justified">
             <li><a href="index"><i class="fa fa-home fa-3x"></i></a></li>
             <li><a href="http://twitter.com/gr8ladies" target="_blank"><i class="fa fa-twitter fa-3x"></i></a></li>


### PR DESCRIPTION
Looked like this in firefox:
![gr8ladies_firefox](https://cloud.githubusercontent.com/assets/3268098/5560244/35ff5066-8d41-11e4-8422-01747defe720.png)

Now it looks like this:
![fixed_firefox_gr8ladies](https://cloud.githubusercontent.com/assets/3268098/5560247/5d912262-8d41-11e4-8324-d2c8c9f90f0c.png)
