### PR TITLE
Fixing carousel on smaller width windows

### DIFF
--- a/grails-app/assets/stylesheets/mobile.css
+++ b/grails-app/assets/stylesheets/mobile.css
@@ -3,7 +3,7 @@
 */
 
 .mobile-friendly {
-	display: none;
+	display: inline;
 }
 
 .regular-friendly {
@@ -11,5 +11,5 @@
 }
 
 .menu-width {
-	min-width: 1162.5px;
+	min-width: 0px;
 }

--- a/grails-app/views/index.gsp
+++ b/grails-app/views/index.gsp
@@ -14,17 +14,20 @@
 
 <body>
 <div class="container">
-    <div id="gr8ladies-carousel" class="carousel slide" data-ride="carousel" style="min-height: 465px;">
+    <div class="mobile-friendly">
+        Gr8Ladies is an organization for the support of women in the Groovy/Grails community. We host educational workshops and meetups.
+    </div>
+    <div id="gr8ladies-carousel" class="carousel slide regular-friendly" data-ride="carousel" style="min-height: 465px; min-width: 1162.5px;">
         <!-- Wrapper for slides -->
         <div class="carousel-inner">
             <div class="item active" align="center">
                 <h1>Sponsors Needed!</h1>
                 <h2>Gr8Ladies is looking for:</h2>
-                <li><h3>Food & Beverages for events</h3></li>
-                <li><h3>Web & Email Hosting</h3></li>
-                <li><h3>Organization Expenses</h3></li>
-                <li><h3>Office Supplies and Printing</h3></li>
-                <li><h3>Travel and Marketing Expenses</h3></li>
+                <h3>Food &amp; Beverages for events</h3>
+                <h3>Web &amp; Email Hosting</h3>
+                <h3>Organization Expenses</h3>
+                <h3>Office Supplies and Printing</h3>
+                <h3>Travel and Marketing Expenses</h3>
                 <g:link class="btn btn-lg btn-success" uri="/sponsors" role="button">Learn More!</g:link>
             </div>
 
@@ -54,6 +57,14 @@
         <!-- Three columns of text below the carousel -->
         <div class="row">
             <div class="col-md-4">
+                <h2>Upcoming Events</h2>
+                <i class="fa fa-calendar fa-5x"></i>
+
+                <p>For a list of our upcoming events, please follow us on twitter
+                @<a href="http://twitter.com/gr8ladies" target="_blank">Gr8Ladies</a>
+                and check our <a href="http://meetup.com/gr8ladies" target="_blank">meetup</a> page.</p>
+            </div><!-- /.col-md-4 -->
+            <div class="col-md-4">
                 <h2>Start a Chapter!</h2>
                 <asset:image src="Gr8LadiesYourTown.png" alt="Gr8Ladies logo your town here"
                              style="width: 70px; height: 70px;"/>
@@ -65,14 +76,6 @@
                 <i class="fa fa-group fa-5x"></i>
 
                 <p>If you'd like to have Gr8Ladies host a workshop with your organization, please email us.</p>
-            </div><!-- /.col-md-4 -->
-            <div class="col-md=4">
-                <h2>Upcoming Events</h2>
-                <i class="fa fa-calendar fa-5x"></i>
-
-                <p>For a list of our upcoming events, please follow us on twitter
-                @<a href="http://twitter.com/gr8ladies" target="_blank">Gr8Ladies</a>
-                and check our <a href="http://meetup.com/gr8ladies" target="_blank">meetup</a> page.</p>
             </div><!-- /.col-md-4 -->
         </div><!-- /.row -->
     </div><!-- /.container -->

--- a/grails-app/views/layouts/header.gsp
+++ b/grails-app/views/layouts/header.gsp
@@ -9,6 +9,7 @@
     <asset:link rel="shortcut icon" href="favicon.ico" type="image/x-icon"/>
     <asset:stylesheet src="application.css"/>
     <asset:stylesheet src="font-awesome/css/font-awesome.min.css"/>
+    <asset:stylesheet src="mobile.css" media="handheld"/>
 <style>
     #social-media-links{
     background-color: #421312;
@@ -18,7 +19,7 @@
 
 <body>
     <div class="container">
-        <div class="nav-wrap">
+        <div class="nav-wrap menu-width">
         <ul id="social-media-links" class="nav nav-pills nav-justified">
             <li><a href="index"><i class="fa fa-home fa-3x"></i></a></li>
             <li><a href="http://twitter.com/gr8ladies" target="_blank"><i class="fa fa-twitter fa-3x"></i></a></li>


### PR DESCRIPTION
This is of questionable front-end quality and probably contains an anti-pattern or two. Also, hasn't been tested on my mobile device. If you know anything about mobile stylesheets, your input would be welcome. I just came up with my own interpretation of how to implement a mobile stylesheet.

The carousel was not looking great when the width of the browser window was narrower than 1200px:
![gr8ladies_carousel_offcenter](https://cloud.githubusercontent.com/assets/3268098/5560596/f0f2e098-8d5c-11e4-868f-63984e9adc9c.png)
There was a gap below the picture, but still grey colored. This was happening because there was a min-height set but the pictures themselves were pretty wide. That picture is 480 x 1200, so at browser widths much less than 1200px, there was the gap. 

The reason there was a min-height appears to be because the first carousel image is actually an html list, not an image, so it wasn't scaling.

To solve this, I decided to add a min-width to the carousel that would eliminate the gap. This would look terrible on small screens like phones. Even without the min-width, the carousel looks pretty terrible on my phone (Jenn, how does it look on yours?). So, I opted to eliminate the carousel on mobile, replacing with a brief description of Gr8Ladies.

Here is what it looks like now when the window is narrower:
![fixed_gr8ladies_carousel_smaller_window](https://cloud.githubusercontent.com/assets/3268098/5560604/a867f222-8d5d-11e4-97b5-540da5352afa.png)

Also, there were some minor tweaks in the list in the carousel: <li> tags without a surrounding <ul></ul> don't do anything. & should not be used in html, it should be &amp; instead, since & alone has special meaning.
